### PR TITLE
feat(business): add slug field to business entity and DTOs

### DIFF
--- a/backend/src/application/business/use-cases/create-business.ts
+++ b/backend/src/application/business/use-cases/create-business.ts
@@ -3,10 +3,12 @@ import { NotAcceptableException } from '@nestjs/common';
 import { Business } from '@/domain/entities';
 import { User } from '@/domain/entities/user';
 import { hashPassword } from '@/shared/utils/hash.util';
+import { UtilsService } from '@/infrastructure/services/utils.service';
 import { RegisterLocalBusinessDto } from '@/infrastructure/dto/business';
 import { BusinessRepository } from '@/domain/interfaces/business-repository';
 
 export class CreateBusinessUseCase {
+  utils = new UtilsService();
   constructor(private readonly businessRepository: BusinessRepository) {}
 
   /**
@@ -27,7 +29,10 @@ export class CreateBusinessUseCase {
     const newUser = new User(user);
     newUser.updatePassword(await hashPassword(user.password));
 
-    const newBusiness = new Business(business);
+    const newBusiness = new Business({
+      ...business,
+      slug: this.utils.camelCaseToSlug(business.name),
+    });
 
     newBusiness.update({
       user: newUser,

--- a/backend/src/application/business/use-cases/promote-user-to-business-owner.ts
+++ b/backend/src/application/business/use-cases/promote-user-to-business-owner.ts
@@ -3,8 +3,10 @@ import { PromoteUserParamsDto } from '../dto/promote-user';
 import { ConflictException, NotAcceptableException } from '@nestjs/common';
 import { Business } from '@/domain/entities';
 import { Role } from '@/domain/constants/role.enum';
+import { UtilsService } from '@/infrastructure/services/utils.service';
 
 export class PromoteUserToBusinessUseCase {
+  utils = new UtilsService();
   constructor(private readonly businessRepository: BusinessRepository) {}
 
   /**
@@ -34,7 +36,10 @@ export class PromoteUserToBusinessUseCase {
     if (exist)
       throw new ConflictException('User already has a business with this name');
 
-    const newBusiness = new Business(dto);
+    const newBusiness = new Business({
+      ...dto,
+      slug: this.utils.camelCaseToSlug(dto.name),
+    });
 
     const business = await this.businessRepository.promoteBusinessOwner(
       newBusiness,

--- a/backend/src/domain/entities/business/business.ts
+++ b/backend/src/domain/entities/business/business.ts
@@ -12,6 +12,7 @@ import { BusinessCategory } from './business-category';
 
 export class Business {
   public id: string | undefined;
+  public slug: string;
   public name: string;
   public description?: string;
   public address?: string;
@@ -39,6 +40,7 @@ export class Business {
   constructor(init: {
     id?: string;
     name: string;
+    slug: string;
     description?: string | null;
     address?: string | null;
     latitude?: number | null;
@@ -63,6 +65,7 @@ export class Business {
     reviews?: Review[];
   }) {
     this.id = init.id;
+    this.slug = init.slug;
     this.name = init.name;
     this.description = init.description ?? undefined;
     this.address = init.address ?? undefined;

--- a/backend/src/infrastructure/dto/business/business-response.dto.ts
+++ b/backend/src/infrastructure/dto/business/business-response.dto.ts
@@ -10,6 +10,11 @@ export class BusinessResponseDto {
   @Expose()
   id: string;
 
+  @ApiProperty({ example: 'PizzaHut' })
+  @IsString()
+  @Expose()
+  slug: string;
+
   @ApiProperty({ example: 'Pizza Hut' })
   @IsString()
   @Expose()

--- a/backend/src/infrastructure/services/utils.service.ts
+++ b/backend/src/infrastructure/services/utils.service.ts
@@ -14,11 +14,12 @@ export class UtilsService {
 
   camelCaseToSlug(text: string): string {
     const normalizedText = text.trim();
-    return normalizedText
+    const formattedText = normalizedText
       .split(/[\s-_]+/)
       .map((word) => {
         return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
       })
       .join('');
+    return `@${formattedText}`;
   }
 }


### PR DESCRIPTION
Introduce a `slug` field to the `Business` entity and related DTOs to uniquely identify businesses. The slug is generated using the `UtilsService`'s `camelCaseToSlug` method, which formats the business name and prefixes it with an '@' symbol. This change enhances business identification and URL-friendly naming in the application.