### PR TITLE
refactor(security): simplify CORS configuration and make origin URL optional

### DIFF
--- a/backend/src/infrastructure/config/config.schema.ts
+++ b/backend/src/infrastructure/config/config.schema.ts
@@ -11,7 +11,7 @@ export const envSchema = joi
     APP_DESCRIPTION: joi.string().optional(),
     APP_VERSION: joi.string().default('1'),
     APP_URL: joi.string().uri().default('http://localhost:3000'),
-    ORIGIN_URL: joi.string().uri().default('http://localhost:3000'),
+    ORIGIN_URL: joi.string().uri().optional(),
     DATABASE_URL: joi.string().required(),
     JWT_SECRET: joi.string().required(),
     JWT_EXPIRES_IN: joi.string().required(),

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -23,12 +23,14 @@ async function bootstrap() {
   const envs = app.get(ConfigService);
   const isProduction = envs.get<string>('app.environment') === 'production';
 
+  const urlOrigin = envs.get<string>('security.originUrl');
+
   // Security
   app.use(cookieParser());
   app.enableCors({
-    origin: envs.get<string>('security.originUrl') ?? '*',
+    origin: urlOrigin ?? '*',
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    credentials: true,
+    credentials: urlOrigin ? true : false,
   });
   app.use(
     helmet({


### PR DESCRIPTION
Extract the origin URL into a variable for better readability and adjust the CORS credentials logic to only allow credentials when a specific origin URL is provided. Also, update the environment schema to make the ORIGIN_URL field optional, improving flexibility in configuration.