### PR TITLE
feat(business): add category filter to business retrieval and rename rating field

### DIFF
--- a/backend/src/application/business/use-cases/getAllBusiness.ts
+++ b/backend/src/application/business/use-cases/getAllBusiness.ts
@@ -1,7 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 
-import { BusinessWhitAverageDto } from '@/infrastructure/dto/business';
+import { BusinessProfileResponseDto } from '@/infrastructure/dto/business';
 import { BusinessRepository } from '@/domain/interfaces/business-repository';
 import {
   PaginationDto,
@@ -14,15 +14,17 @@ export class GetAllBusinessUseCase {
   async execute({
     page = 1,
     limit = 10,
-  }: Partial<PaginationDto>): Promise<
-    PaginationResponseDto<BusinessWhitAverageDto[]>
+    category,
+  }: Partial<PaginationDto & { category?: string }>): Promise<
+    PaginationResponseDto<BusinessProfileResponseDto[]>
   > {
     const skip = (page - 1) * limit;
 
-    const count = await this.businessRepository.countBusiness();
+    const count = await this.businessRepository.countBusiness(category);
     const businesses = await this.businessRepository.getAllBusiness({
       skip,
       limit,
+      category,
     });
 
     if (!businesses) throw new NotFoundException('Businesses not found.');
@@ -32,7 +34,7 @@ export class GetAllBusinessUseCase {
       prev: page > 1 ? page - 1 : null,
       next: page * limit < count ? page + 1 : null,
       limit,
-      data: plainToInstance(BusinessWhitAverageDto, businesses),
+      data: plainToInstance(BusinessProfileResponseDto, businesses),
     };
   }
 }

--- a/backend/src/domain/entities/business/business-availability.ts
+++ b/backend/src/domain/entities/business/business-availability.ts
@@ -12,24 +12,25 @@ export class Availability {
   public business?: Business;
   public service?: BusinessService;
 
-  constructor(params: {
+  constructor(init: {
     id?: string;
     dayOfWeek: number;
     startTime: Date;
     endTime: Date;
     businessId: string;
     serviceId?: string | null;
+
     business?: Business;
     service?: BusinessService;
   }) {
-    this.id = params.id;
-    this.dayOfWeek = params.dayOfWeek;
-    this.startTime = params.startTime;
-    this.endTime = params.endTime;
-    this.businessId = params.businessId;
-    this.serviceId = params.serviceId ?? null;
-    this.business = params.business;
-    this.service = params.service;
+    this.id = init.id;
+    this.dayOfWeek = init.dayOfWeek;
+    this.startTime = init.startTime;
+    this.endTime = init.endTime;
+    this.businessId = init.businessId;
+    this.serviceId = init.serviceId ?? null;
+    this.business = init.business;
+    this.service = init.service;
   }
 
   /**

--- a/backend/src/domain/interfaces/business-repository.ts
+++ b/backend/src/domain/interfaces/business-repository.ts
@@ -3,7 +3,7 @@ import { Role } from '../constants/role.enum';
 import { IPagination } from '@/shared/interfaces/pagination.interface';
 
 export interface BusinessRepository {
-  countBusiness(): Promise<number>;
+  countBusiness(category?: string): Promise<number>;
   searchBusiness(
     skip: number,
     limit: number,
@@ -16,7 +16,7 @@ export interface BusinessRepository {
   ): Promise<{ business: Business; rate: number } | null>;
   findBusinessByOwnerId(id: string): Promise<Business | null>;
   getAllBusiness(
-    data: Partial<IPagination>,
+    data: Partial<IPagination & { category?: string }>,
   ): Promise<(Business & { rateAvg: number })[] | null>;
   saveLocalBusiness(entity: Business): Promise<Business>;
   promoteBusinessOwner(

--- a/backend/src/infrastructure/controllers/business.controller.ts
+++ b/backend/src/infrastructure/controllers/business.controller.ts
@@ -126,7 +126,7 @@ export class BusinessController {
       BusinessProfileResponseDto,
       result.business,
     );
-    business.rating_average = result.rate;
+    business.rateAvg = result.rate;
 
     return business;
   }

--- a/backend/src/infrastructure/dto/business/business-profile.dto.ts
+++ b/backend/src/infrastructure/dto/business/business-profile.dto.ts
@@ -1,7 +1,8 @@
 import { Type } from 'class-transformer';
-import { IsNumber } from 'class-validator';
+import { IsNumber, ValidateNested } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
+import { Review } from '@/domain/entities/review';
 import { AvailabilityResponseDto } from '../availability';
 import { BusinessProfileDto } from './profile-response.dto';
 import { BusinessResponseDto } from './business-response.dto';
@@ -12,25 +13,36 @@ import { BusinessCategoryResponseDto } from './categories-response.dto';
 export class BusinessProfileResponseDto extends BusinessResponseDto {
   @ApiProperty({ type: [BusinessImageResponseDto] })
   @Type(() => BusinessImageResponseDto)
+  @ValidateNested({ each: true })
   images?: BusinessImageResponseDto[];
 
   @ApiProperty({ type: [BusinessServicesResponseDto] })
   @Type(() => BusinessServicesResponseDto)
+  @ValidateNested({ each: true })
   services?: BusinessServicesResponseDto[];
+
+  @ApiProperty({ type: [Review] })
+  @Type(() => Review)
+  @ValidateNested({ each: true })
+  reviews?: Review[];
 
   @ApiProperty({ type: BusinessProfileDto })
   @Type(() => BusinessProfileDto)
+  @ValidateNested({ each: true })
   businessProfile?: BusinessProfileDto;
 
   @ApiProperty({ type: [BusinessCategoryResponseDto] })
   @Type(() => BusinessCategoryResponseDto)
+  @ValidateNested({ each: true })
   categories?: BusinessCategoryResponseDto[];
 
   @ApiProperty({ type: [AvailabilityResponseDto] })
   @Type(() => AvailabilityResponseDto)
+  @ValidateNested({ each: true })
   availability?: AvailabilityResponseDto[];
 
-  @ApiProperty({ example: '1' })
+  @ApiProperty({ example: 4.5 })
   @IsNumber()
-  rating_average: number;
+  @Type(() => Number)
+  rateAvg?: number;
 }

--- a/backend/src/infrastructure/dto/business/business-response.dto.ts
+++ b/backend/src/infrastructure/dto/business/business-response.dto.ts
@@ -1,7 +1,6 @@
-import { Exclude, Expose, Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose, Type } from 'class-transformer';
 import { IsDate, IsString, IsUrl } from 'class-validator';
-import { Review } from '@/domain/entities';
 
 @Exclude()
 export class BusinessResponseDto {
@@ -60,15 +59,4 @@ export class BusinessResponseDto {
   @IsDate()
   @Expose()
   updatedAt: Date;
-
-  @ApiProperty({ type: [Review] })
-  @Type(() => Review)
-  @Expose()
-  reviews?: Review[];
-}
-
-export class BusinessWhitAverageDto extends BusinessResponseDto {
-  @ApiProperty({ example: 4.5 })
-  @Expose()
-  rateAvg?: number;
 }

--- a/backend/src/infrastructure/dto/pagination.dto.ts
+++ b/backend/src/infrastructure/dto/pagination.dto.ts
@@ -49,6 +49,11 @@ export class PaginationDto {
   @Min(1)
   public limit?: number;
 
+  @ApiPropertyOptional({ example: 'Health & Wellness' })
+  @IsOptional()
+  @IsString()
+  public category?: string;
+
   @ApiPropertyOptional({ example: 'desc' })
   @IsOptional()
   @IsString()

--- a/backend/src/infrastructure/repositories/business.repository.ts
+++ b/backend/src/infrastructure/repositories/business.repository.ts
@@ -28,8 +28,21 @@ export class BusinessPrismaRepository implements BusinessRepository {
    *
    * @returns A promise that resolves with the total count of businesses.
    */
-  async countBusiness(): Promise<number> {
-    return this.prisma.business.count();
+  async countBusiness(category?: string): Promise<number> {
+    return this.prisma.business.count({
+      where: {
+        isDeleted: false,
+        ...(category && {
+          categories: {
+            some: {
+              category: {
+                en_name: { contains: category, mode: 'insensitive' },
+              },
+            },
+          },
+        }),
+      },
+    });
   }
 
   /**
@@ -175,18 +188,37 @@ export class BusinessPrismaRepository implements BusinessRepository {
   }
 
   /**
-   * Retrieves a list of all businesses with their categories and average rating.
-   *
-   * @param pagination - Optional pagination parameters.
+   * Retrieves a paginated list of businesses, with an optional filter for category.
+   * The list includes the business details, business profile, availability, and categories.
+   * The response is also enriched with the average rating of each business.
+   * @param skip - The number of businesses to skip, for pagination.
+   * @param limit - The maximum number of businesses to retrieve.
+   * @param category - (Optional) The category filter to search businesses by category.
    * @returns A promise that resolves with an array of Business objects, or null if no businesses are found.
    */
-  async getAllBusiness({ skip, limit }: Partial<IPagination>) {
+  async getAllBusiness({
+    skip,
+    limit,
+    category,
+  }: Partial<IPagination & { category?: string }>) {
     const businesses = await this.prisma.business.findMany({
-      where: { isDeleted: false },
+      where: {
+        isDeleted: false,
+        ...(category && {
+          categories: {
+            some: {
+              category: {
+                en_name: { contains: category, mode: 'insensitive' },
+              },
+            },
+          },
+        }),
+      },
       skip,
       take: limit,
       include: {
         businessProfile: { omit: { businessId: true } },
+        availability: true,
         categories: {
           include: { category: true },
           omit: { businessId: true },
@@ -206,6 +238,9 @@ export class BusinessPrismaRepository implements BusinessRepository {
         const businessEntity = new Business({
           ...business,
           businessProfile: business.businessProfile as BusinessProfile,
+          availability: business.availability.map(
+            (item) => new Availability(item),
+          ),
           latitude: business.latitude?.toNumber() ?? 0,
           longitude: business.longitude?.toNumber() ?? 0,
           categories: business.categories as BusinessCategory[],


### PR DESCRIPTION
- Added category filter support to `getAllBusiness` and `countBusiness` methods to allow filtering businesses by category
- Renamed `rating_average` field to `rateAvg` in `BusinessProfileResponseDto` for consistency
- Updated related DTOs, interfaces, and repository logic to support category filtering and field renaming