### PR TITLE
fix(cors): allow localhost:3000 in CORS and CSP for development

### DIFF
--- a/backend/src/infrastructure/orm/seed.ts
+++ b/backend/src/infrastructure/orm/seed.ts
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
       {
         name: 'Rentas y Servicios',
         en_name: 'Rentals & Services',
-        icon: 'HandShake',
+        icon: 'Handshake',
       },
       {
         name: 'Eventos y Celebraciones',

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -28,7 +28,7 @@ async function bootstrap() {
   // Security
   app.use(cookieParser());
   app.enableCors({
-    origin: urlOrigin ?? '*',
+    origin: [urlOrigin ?? '*', 'http://localhost:3000'],
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     credentials: urlOrigin ? true : false,
   });
@@ -44,6 +44,7 @@ async function bootstrap() {
             "'self'",
             'https://accounts.google.com',
             'https://*.googleapis.com',
+            'http://localhost:3000',
             urlOrigin ?? '*',
             // payment provider url
           ],


### PR DESCRIPTION
Enable CORS and Content Security Policy (CSP) to include 'http://localhost:3000' to facilitate local development and testing. This ensures that the backend can interact seamlessly with the frontend running on localhost during development.