### PR TITLE
fix(cors): enable credentials for all origins

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -30,7 +30,7 @@ async function bootstrap() {
   app.enableCors({
     origin: [urlOrigin ?? '*', 'http://localhost:3000'],
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    credentials: urlOrigin ? true : false,
+    credentials: true,
   });
   app.use(
     helmet({


### PR DESCRIPTION
Previously, credentials were only enabled when a specific URL origin was provided. This change ensures credentials are always enabled, improving security and consistency across all environments.