### PR TITLE
refactor(review): update review DTO and repository to include user profile

### DIFF
--- a/backend/src/infrastructure/dto/review/res-reviews.dto.ts
+++ b/backend/src/infrastructure/dto/review/res-reviews.dto.ts
@@ -1,5 +1,3 @@
-import { Type } from 'class-transformer';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsDate,
   IsNumber,
@@ -7,9 +5,11 @@ import {
   MinLength,
   ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import { WorkResponseDto } from '@/infrastructure/dto/work/res-work.dto';
-import { ResponseUserDto } from '@/infrastructure/dto/user/user-response.dto';
+import { ReviewUserWithProfileDto } from '@/infrastructure/dto/user/user-response.dto';
 import { BusinessResponseDto } from '@/infrastructure/dto/business/business-response.dto';
 
 export class ResReviewsDto {
@@ -43,10 +43,10 @@ export class ResReviewsDto {
   @IsString()
   clientId: string;
 
-  @ApiPropertyOptional({ type: ResponseUserDto })
-  @Type(() => ResponseUserDto)
+  @ApiPropertyOptional({ type: ReviewUserWithProfileDto })
+  @Type(() => ReviewUserWithProfileDto)
   @ValidateNested({ each: true })
-  client?: ResponseUserDto;
+  client?: ReviewUserWithProfileDto;
 
   @ApiProperty({ example: '1' })
   @IsString()

--- a/backend/src/infrastructure/dto/user/user-response.dto.ts
+++ b/backend/src/infrastructure/dto/user/user-response.dto.ts
@@ -1,9 +1,16 @@
-import { Role, TRole } from '@/domain/constants/role.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose, Type } from 'class-transformer';
-import { IsBoolean, IsDate, IsEnum, IsString } from 'class-validator';
-import { BusinessResponseDto } from '../business';
+import {
+  IsBoolean,
+  IsDate,
+  IsEnum,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 
+import { BusinessResponseDto } from '../business';
+import { Role, TRole } from '@/domain/constants/role.enum';
+import { UserProfileResponseDto } from './userprofile-response.dto';
 
 @Exclude()
 export class ResponseUserDto {
@@ -56,4 +63,12 @@ export class ResponseUserDto {
   @Expose()
   @Type(() => BusinessResponseDto)
   business?: BusinessResponseDto[];
+}
+
+export class ReviewUserWithProfileDto extends ResponseUserDto {
+  @ApiProperty({ type: UserProfileResponseDto })
+  @Expose()
+  @Type(() => UserProfileResponseDto)
+  @ValidateNested({ each: true })
+  userProfile?: UserProfileResponseDto;
 }

--- a/backend/src/infrastructure/repositories/review.repository.ts
+++ b/backend/src/infrastructure/repositories/review.repository.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { Review } from '@/domain/entities';
 import { PrismaService } from '../orm/prisma.service';
 import { ReviewRepository } from '@/domain/interfaces/review-repository';
+import { User, UserProfile } from '@/domain/entities/user';
+import { Role } from '@/domain/constants/role.enum';
 
 @Injectable()
 export class ReviewPrismaRepository implements ReviewRepository {
@@ -61,6 +63,13 @@ export class ReviewPrismaRepository implements ReviewRepository {
       where: {
         businessId: id,
       },
+      include: {
+        client: {
+          include: {
+            userProfile: true,
+          },
+        },
+      },
       skip,
       take: limit,
       orderBy: {
@@ -68,7 +77,17 @@ export class ReviewPrismaRepository implements ReviewRepository {
       },
     });
 
-    return result.map((review) => new Review(review));
+    return result.map(
+      (review) =>
+        new Review({
+          ...review,
+          client: new User({
+            ...review.client,
+            userType: review.client.userType as Role,
+            userProfile: review.client.userProfile as UserProfile,
+          }),
+        }),
+    );
   }
 
   /**


### PR DESCRIPTION
Update `ResReviewsDto` to use `ReviewUserWithProfileDto` instead of `ResponseUserDto` to include user profile information. Modify `ReviewPrismaRepository` to include user profile in the query and map the result accordingly. This change ensures that the review data includes detailed user profile information.